### PR TITLE
workspace+cli+lib+test: Add --chtime and --chmod flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       run: ./build.sh build
     
     - name: Test
-      run: ./build.sh test
+      run: |
+        groupadd testgroup && \
+        usermod -a -G testgroup \$(whoami) && \
+        ./build.sh test
     
     - name: Bash integration tests
       run: ./build.sh test integration-bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
     
     - name: Test
       run: |
-        groupadd testgroup && \
-        usermod -a -G testgroup \$(whoami) && \
+        groupadd testgroup
+        usermod -a -G testgroup $(whoami)
         ./build.sh test
     
     - name: Bash integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ jobs:
       run: ./build.sh build
     
     - name: Test
-      run: |
-        groupadd testgroup
-        usermod -a -G testgroup $(whoami)
-        ./build.sh test
+      run: ./build.sh test
     
     - name: Bash integration tests
       run: ./build.sh test integration-bash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ losing it. Everything you put in once stays there forever.
 - **Revision**: A snapshot of the repository at a specific point in time, usually created by
   a `merge` operation.
 
+
+### Modification Tracking
+
+By default, only changes to the file contents are tracked. The file's metadata (ownership, mtime,
+and mode) are stored in the repository, but modifications to these metadata are not detected in
+consecutive merges unless the `--chown`, `--chmod`, or `--chtime` flags are used.
+
+When merging new files from the repository, mtime and mode are restored from the repository but not
+ownership. This is because ownership is highly dependent on the user's environment whereas mtime
+and mode are not.
+
+This way of tracking modifications is best suited for the main use case of cling-sync: making sure
+user data is never lost without the complications of a "real" backup system.
+
 ## OS Support
 
 Currently, the main focus is on supporting MacOS and Linux. It should work on Windows, but is not

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ run_build() {
             cli)
                 echo ">>> Building CLI"
                 go build "$@" -o cling-sync ./cli
-                if [ "${CS_DARWIN_CODESIGN:-}" != "" -a "$(uname -s)" == "Darwin" ]; then
+                if [ -n "${CS_DARWIN_CODESIGN:-}" ] && [ "$(uname -s)" = "Darwin" ]; then
                     echo ">>> Codesigning CLI"
                     codesign --sign "${CS_DARWIN_CODESIGN}" --force --options runtime ./cling-sync
                 fi

--- a/lib/metadata_test.go
+++ b/lib/metadata_test.go
@@ -182,54 +182,67 @@ func TestFileMetadata(t *testing.T) {
 		)
 
 		actual := *base
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 
 		actual = *base
 		actual.BlockIds = append(actual.BlockIds, td.BlockId("3"))
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, true), "BlockIds are ignored")
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll), "BlockIds are ignored")
 
 		actual = *base
-		actual.ModeAndPerm += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		actual.ModeAndPerm = 0o111
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataMode))
+
+		actual = *base
+		actual.ModeAndPerm |= ModeDir
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataMode))
+
+		actual = *base
+		actual.ModeAndPerm |= ModeSymlink
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataMode))
 
 		actual = *base
 		actual.MTimeSec += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataMTime))
 
 		actual = *base
 		actual.MTimeNSec += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataMTime))
 
 		actual = *base
 		actual.Size += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 
 		actual = *base
 		actual.FileHash[0] += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 
 		actual = *base
 		actual.SymlinkTarget += "_modified"
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 
 		actual = *base
 		actual.UID += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, false))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataOwnership))
 
 		actual = *base
 		actual.GID += 1
-		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, true))
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, false))
+		assert.Equal(false, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll^RestorableMetadataOwnership))
 
 		// Birthtime is ignored because it is not restorable (on most systems).
 		actual = *base
 		actual.BirthtimeSec += 1
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 
 		actual = *base
 		actual.BirthtimeNSec += 1
-		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, true))
+		assert.Equal(true, base.IsEqualRestorableAttributes(&actual, RestorableMetadataAll))
 	})
 
 	t.Run("NewEmptyDirFileMetadata", func(t *testing.T) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -134,7 +134,7 @@ test_basic_scenario() {
         cmd "echo bb > b.txt"
         cmd "touch -d '2025-06-28T13:33:50+02:00' b.txt"
         cmd "echo 'd' > dir1/d.txt"
-        cling-sync merge --no-progress --message "second commit"
+        cling-sync merge --no-progress --chtime --message "second commit"
 
         log $green">>> A new revision should have been created"
         assert "cling-sync log --short | wc -l" "echo 2"

--- a/test/test_docker.sh
+++ b/test/test_docker.sh
@@ -27,6 +27,8 @@ podman run --rm --name cling-sync-test \
         Xvfb :99 & \
         eval $(dbus-launch) && \
         echo '\n' | gnome-keyring-daemon --unlock && \
+        groupadd testgroup && \
+        usermod -a -G testgroup \$(whoami) && \
         ./build.sh test test -v && \
         ./build.sh test integration-bash \
         "

--- a/workspace/merge_test.go
+++ b/workspace/merge_test.go
@@ -384,12 +384,12 @@ func TestMerge(t *testing.T) {
 
 		// Merge the changes - this should fail because the GUID and/or UID should not exist.
 		opts := wstd.MergeOptions()
-		opts.Chown = true
+		opts.RestorableMetadataFlag |= lib.RestorableMetadataOwnership
 		_, err = Merge(w.Workspace, r.Repository, opts)
 		assert.Error(err, "failed to restore file owner 1234 and group 5678 for a.txt")
 
 		// Try a second time without `Chown`.
-		opts.Chown = false
+		opts.RestorableMetadataFlag ^= lib.RestorableMetadataOwnership
 		_, err = Merge(w.Workspace, r.Repository, opts)
 		assert.NoError(err)
 		assert.Equal(fs.FileMode(0o700).Perm(), w.Stat("a.txt").Mode().Perm())
@@ -421,12 +421,12 @@ func TestMerge(t *testing.T) {
 
 		// Merge should fail if we take ownership into account.
 		opts := wstd.MergeOptions()
-		opts.Chown = true
+		opts.RestorableMetadataFlag |= lib.RestorableMetadataOwnership
 		_, err = Merge(w.Workspace, r.Repository, opts)
 		assert.Error(err, "MergeConflictsError")
 
 		// Merge should succeed if we ignore ownership.
-		opts.Chown = false
+		opts.RestorableMetadataFlag ^= lib.RestorableMetadataOwnership
 		revId1, err = Merge(w.Workspace, r.Repository, opts)
 		assert.NoError(err)
 		assert.Equal(revId1, w2revId2)

--- a/workspace/staging.go
+++ b/workspace/staging.go
@@ -132,7 +132,7 @@ func (s *Staging) Finalize() (*lib.Temp[lib.RevisionEntry], error) {
 //	compareOwnership: If `true`, ownership of the file is compared.
 func (s *Staging) MergeWithSnapshot( //nolint:funlen
 	snapshot *lib.Temp[lib.RevisionEntry],
-	compareOwnership bool,
+	restorableMetadataFlag lib.RestorableMetadataFlag,
 ) (*lib.Temp[lib.RevisionEntry], error) {
 	stgTemp, err := s.Finalize()
 	if err != nil {
@@ -220,7 +220,7 @@ func (s *Staging) MergeWithSnapshot( //nolint:funlen
 		}
 		c := lib.RevisionEntryPathCompare(stg, rev)
 		if c == 0 { //nolint:gocritic
-			if !stg.Metadata.IsEqualRestorableAttributes(rev.Metadata, compareOwnership) {
+			if !stg.Metadata.IsEqualRestorableAttributes(rev.Metadata, restorableMetadataFlag) {
 				// Write an update.
 				if err := add(stg.Path, lib.RevisionEntryUpdate, stg.Metadata); err != nil {
 					return nil, err

--- a/workspace/staging_test.go
+++ b/workspace/staging_test.go
@@ -57,7 +57,7 @@ func TestStaging(t *testing.T) {
 		// Merge the staging with a snapshot of the remote revision.
 		snapshot, err := lib.NewRevisionSnapshot(r.Repository, remoteRev1, td.NewFS(t))
 		assert.NoError(err)
-		merged, err := staging.MergeWithSnapshot(snapshot, true)
+		merged, err := staging.MergeWithSnapshot(snapshot, lib.RestorableMetadataAll)
 		assert.NoError(err)
 		assert.Equal([]lib.TestRevisionEntryInfo{
 			{"a.txt", lib.RevisionEntryUpdate, 0o600, td.SHA256("a")},

--- a/workspace/status.go
+++ b/workspace/status.go
@@ -58,10 +58,10 @@ func (s StatusFiles) Summary() string {
 }
 
 type StatusOptions struct {
-	PathFilter      lib.PathFilter
-	Monitor         StagingEntryMonitor
-	Chown           bool
-	UseStagingCache bool
+	PathFilter             lib.PathFilter
+	Monitor                StagingEntryMonitor
+	RestorableMetadataFlag lib.RestorableMetadataFlag
+	UseStagingCache        bool
 }
 
 func Status(ws *Workspace, repository *lib.Repository, opts *StatusOptions, tmpFS lib.FS) (StatusFiles, error) {
@@ -85,7 +85,7 @@ func Status(ws *Workspace, repository *lib.Repository, opts *StatusOptions, tmpF
 	if err != nil {
 		return nil, lib.WrapErrorf(err, "failed to scan changes")
 	}
-	revisionTemp, err := staging.MergeWithSnapshot(snapshot, opts.Chown)
+	revisionTemp, err := staging.MergeWithSnapshot(snapshot, opts.RestorableMetadataFlag)
 	if err != nil {
 		return nil, lib.WrapErrorf(err, "failed to merge staging and revision snapshot")
 	}

--- a/workspace/status_test.go
+++ b/workspace/status_test.go
@@ -210,7 +210,7 @@ func TestStatus(t *testing.T) {
 
 		// Status taking ownership into account.
 		opts := wstd.StatusOptions()
-		opts.Chown = true
+		opts.RestorableMetadataFlag = lib.RestorableMetadataOwnership
 		status, err := Status(w2.Workspace, r.Repository, opts, td.NewFS(t))
 		assert.NoError(err)
 		assert.Equal([]string{
@@ -218,7 +218,7 @@ func TestStatus(t *testing.T) {
 		}, statusFilesString(status))
 
 		// Status not taking ownership into account.
-		opts.Chown = false
+		opts.RestorableMetadataFlag ^= lib.RestorableMetadataOwnership
 		status, err = Status(w2.Workspace, r.Repository, opts, td.NewFS(t))
 		assert.NoError(err)
 		assert.Equal([]string{}, statusFilesString(status))

--- a/workspace/testdata.go
+++ b/workspace/testdata.go
@@ -62,7 +62,7 @@ func (wstd WorkspaceTestData) CommitMonitor() *TestCommitMonitor {
 }
 
 func (wstd WorkspaceTestData) StatusOptions() *StatusOptions {
-	return &StatusOptions{nil, wstd.StagingMonitor(), true, false}
+	return &StatusOptions{nil, wstd.StagingMonitor(), lib.RestorableMetadataAll, false}
 }
 
 func (wstd WorkspaceTestData) MergeOptions() *MergeOptions {
@@ -72,13 +72,22 @@ func (wstd WorkspaceTestData) MergeOptions() *MergeOptions {
 		wstd.CommitMonitor(),
 		"author",
 		"message",
-		true,
+		lib.RestorableMetadataAll,
 		false,
 	}
 }
 
 func (wstd WorkspaceTestData) LsOptions(revisionId lib.RevisionId) *LsOptions {
 	return &LsOptions{RevisionId: revisionId} //nolint:exhaustruct
+}
+
+func (wstd WorkspaceTestData) CpOptions(revisionId lib.RevisionId) *CpOptions {
+	return &CpOptions{
+		revisionId,
+		wstd.CpMonitor(),
+		nil,
+		lib.RestorableMetadataAll,
+	}
 }
 
 type TestCpMonitor struct {


### PR DESCRIPTION
This changes the default behavior of `merge` and `status` to not respect file modification times and file modes (except for ModeDir and ModeSymlink).

This aligns better with our goals of being an easy-to-use personal archiving tool.